### PR TITLE
Allow conditional PR image push based on PR label

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,10 +27,13 @@ jobs:
         username: ${{ secrets.LCAS_REGISTRY_PUSHER }}
         # Password or personal access token used to log against the Docker registry
         password: ${{ secrets.LCAS_REGISTRY_TOKEN }}
+    - name: Get PR labels
+      id: pr-labels
+      uses: joerick/pr-labels-action@v1.0.8
     - name: Debug echo
-      run: echo "github.event.label.name is ${{ github.event.label.name }} and github.event_name is ${{ github.event_name }} and env.BRANCH is ${{ env.BRANCH }}"
+      run: echo "steps.pr-labels.outputs.labels is ${{ steps.pr-labels.outputs.labels }} ${{ contains(steps.pr-labels.outputs.labels, ' docker-build ') }}, github.event.label.name is ${{ github.event.label.name }} and github.event_name is ${{ github.event_name }} and env.BRANCH is ${{ env.BRANCH }}"
     - name: Build and push noetic on focal docker-build PR
-      if: ${{ github.event.label.name == 'docker-build' && github.event_name == 'pull_request' }}
+      if: ${{ contains(steps.pr-labels.outputs.labels, ' docker-build ') && github.event_name == 'pull_request' }}
       uses: docker/build-push-action@v2
       with:
         context: .

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -31,7 +31,7 @@ jobs:
       id: pr-labels
       uses: joerick/pr-labels-action@v1.0.8
     - name: Debug echo
-      run: echo "steps.pr-labels.outputs.labels is ${{ steps.pr-labels.outputs.labels }} ${{ contains(steps.pr-labels.outputs.labels, ' docker-build ') }}, github.event.label.name is ${{ github.event.label.name }} and github.event_name is ${{ github.event_name }} and env.BRANCH is ${{ env.BRANCH }}"
+      run: echo "github.head_ref is ${{ github.head_ref }}, steps.pr-labels.outputs.labels is ${{ steps.pr-labels.outputs.labels }} ${{ contains(steps.pr-labels.outputs.labels, ' docker-build ') }}, github.event.label.name is ${{ github.event.label.name }} and github.event_name is ${{ github.event_name }} and env.BRANCH is ${{ env.BRANCH }}"
     - name: Build and push noetic on focal docker-build PR
       if: ${{ contains(steps.pr-labels.outputs.labels, ' docker-build ') && github.event_name == 'pull_request' }}
       uses: docker/build-push-action@v2
@@ -40,7 +40,7 @@ jobs:
         file: ./lcastor_docker/Dockerfile
         platforms: linux/amd64
         push: true
-        tags: lcas.lincoln.ac.uk/lcastor/lcastor_base:${{ env.BRANCH }}
+        tags: lcas.lincoln.ac.uk/lcastor/lcastor_base:${{ github.head_ref }}
 #         run: docker build --file ./lcastor_docker/Dockerfile --tag lcas.lincoln.ac.uk/lcastor/lcastor_base:latest
         build-args: |
             UID=1001

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,6 +27,8 @@ jobs:
         username: ${{ secrets.LCAS_REGISTRY_PUSHER }}
         # Password or personal access token used to log against the Docker registry
         password: ${{ secrets.LCAS_REGISTRY_TOKEN }}
+    - name: Debug echo
+      run: echo "github.event.label.name is ${{ github.event.label.name }} and github.event_name is ${{ github.event_name }} and env.BRANCH is ${{ env.BRANCH }}"
     - name: Build and push noetic on focal docker-build PR
       if: ${{ github.event.label.name == 'docker-build' && github.event_name == 'pull_request' }}
       uses: docker/build-push-action@v2

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,8 +14,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: What
-      run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
     - name: Docker Login LCAS
       # You may pin to the exact commit or the version.
       # uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
@@ -31,9 +29,9 @@ jobs:
       id: pr-labels
       uses: joerick/pr-labels-action@v1.0.8
     - name: Debug echo
-      run: echo "github.head_ref is ${{ github.head_ref }}, steps.pr-labels.outputs.labels is ${{ steps.pr-labels.outputs.labels }} ${{ contains(steps.pr-labels.outputs.labels, ' docker-build ') }}, github.event.label.name is ${{ github.event.label.name }} and github.event_name is ${{ github.event_name }} and env.BRANCH is ${{ env.BRANCH }}"
+      run: echo "github.head_ref is ${{ github.head_ref }}, steps.pr-labels.outputs.labels is ${{ steps.pr-labels.outputs.labels }} ${{ contains(steps.pr-labels.outputs.labels, ' docker-build ') }}, github.event.label.name is ${{ github.event.label.name }} and github.event_name is ${{ github.event_name }}"
     - name: Build and push noetic on focal docker-build PR
-      if: ${{ contains(steps.pr-labels.outputs.labels, ' docker-build ') && github.event_name == 'pull_request' }}
+      if: ${{ github.event_name == 'pull_request' && contains(steps.pr-labels.outputs.labels, ' docker-build ') }}
       uses: docker/build-push-action@v2
       with:
         context: .
@@ -46,7 +44,7 @@ jobs:
             UID=1001
             GID=1001
     - name: Build and push noetic on focal 
-      if: ${{ github.event.label.name != 'docker-build' }}
+      if: ${{ github.event_name != 'pull_request' || ! contains(steps.pr-labels.outputs.labels, ' docker-build ') }}
       uses: docker/build-push-action@v2
       with:
         context: .

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,9 +9,7 @@ on:
     paths: ['lcastor_docker/Dockerfile']
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -29,7 +27,21 @@ jobs:
         username: ${{ secrets.LCAS_REGISTRY_PUSHER }}
         # Password or personal access token used to log against the Docker registry
         password: ${{ secrets.LCAS_REGISTRY_TOKEN }}
-    - name: Build and push noetic on focal
+    - name: Build and push noetic on focal docker-build PR
+      if: ${{ github.event.label.name == 'docker-build' && github.event_name == 'pull_request' }}
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./lcastor_docker/Dockerfile
+        platforms: linux/amd64
+        push: true
+        tags: lcas.lincoln.ac.uk/lcastor/lcastor_base:${{ env.BRANCH }}
+#         run: docker build --file ./lcastor_docker/Dockerfile --tag lcas.lincoln.ac.uk/lcastor/lcastor_base:latest
+        build-args: |
+            UID=1001
+            GID=1001
+    - name: Build and push noetic on focal 
+      if: ${{ github.event.label.name != 'docker-build' }}
       uses: docker/build-push-action@v2
       with:
         context: .

--- a/lcastor_docker/Dockerfile
+++ b/lcastor_docker/Dockerfile
@@ -53,4 +53,3 @@ RUN cd /home/lcastor/ros_ws; . /opt/ros/${ROS_DISTRO}/setup.sh; catkin build
 # Create entrypoint for image
 # COPY entrypoint.sh .
 ENTRYPOINT ["/bin/bash", "/home/lcastor/ros_ws/src/LCASTOR/lcastor_docker/entrypoint.sh"]
-

--- a/lcastor_docker/Dockerfile
+++ b/lcastor_docker/Dockerfile
@@ -53,3 +53,4 @@ RUN cd /home/lcastor/ros_ws; . /opt/ros/${ROS_DISTRO}/setup.sh; catkin build
 # Create entrypoint for image
 # COPY entrypoint.sh .
 ENTRYPOINT ["/bin/bash", "/home/lcastor/ros_ws/src/LCASTOR/lcastor_docker/entrypoint.sh"]
+


### PR DESCRIPTION
The current behaviour for pushing the docker image is:
- main branch => push with the `latest` tag
- PR with docker-build label => push with `branch_name` tag
- PR without docker-build label ==> do not push (only build)